### PR TITLE
DIG-2080: add analysis dates to analyses that don't have them

### DIFF
--- a/small_dataset_csv/genomic.json
+++ b/small_dataset_csv/genomic.json
@@ -119,6 +119,7 @@
             },
             "metadata": {
                 "analysis_type": "sequence_variation",
+                "analysis_date": "2024-10-23",
                 "reference": "hg38"
             },
             "samples": [
@@ -145,6 +146,7 @@
             },
             "metadata": {
                 "analysis_type": "sequence_variation",
+                "analysis_date": "2024-10-23",
                 "reference": "hg38"
             },
             "samples": [
@@ -171,6 +173,7 @@
             },
             "metadata": {
                 "analysis_type": "sequence_variation",
+                "analysis_date": "2024-10-23",
                 "reference": "hg38"
             },
             "samples": [


### PR DESCRIPTION
For integration tests, we need to make sure that analyses either have a date specified in their vcf files or have the analysis date specified in the ingest file.